### PR TITLE
Add universe install option

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -36,6 +36,13 @@ This README is a good place to get started with `hashprng`, in particular the fo
 
 ### Installing the package
 
+
+Install the latest GitHub released version of the package with:
+
+```{r, eval = FALSE}
+install.packages("hashprng", repos = "https://epinowcast.r-universe.dev")
+```
+
 Install the development version (whilst we strive to limit breaking changes or the introduction of bugs during development this version may contain both) from GitHub using the following,
 
 ```{r, eval = FALSE}

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ set than presented here, we also provide a range of other reosources.
 
 ### Installing the package
 
+Install the latest GitHub released version of the package with:
+
+``` r
+install.packages("hashprng", repos = "https://epinowcast.r-universe.dev")
+```
+
 Install the development version (whilst we strive to limit breaking
 changes or the introduction of bugs during development this version may
 contain both) from GitHub using the following,


### PR DESCRIPTION
This PR adds a universe install opton configured to be the latest GitHub release. This gives users a stable install location which may still be ahead of any CRAN release (i.e., minor releases).